### PR TITLE
Final cleanup before V0 deployment

### DIFF
--- a/VRCX-API/Helpers/DateTimeConverter.cs
+++ b/VRCX-API/Helpers/DateTimeConverter.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace VRCX_API.Helpers
+{
+    /// <summary>
+    /// Converter to match GitHubs DateTimeOffset formatting
+    /// </summary>
+    public class DateTimeConverter : JsonConverter<DateTimeOffset?>
+    {
+        public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Debug.Assert(typeToConvert == typeof(DateTimeOffset));
+            string? str = reader.GetString();
+            return string.IsNullOrWhiteSpace(str) ? null : DateTimeOffset.Parse(str);
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTimeOffset? value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value?.ToUniversalTime().ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssZ"));
+        }
+    }
+}

--- a/VRCX-API/Helpers/IgnoreEmptyStringNullableEnumConverter.cs
+++ b/VRCX-API/Helpers/IgnoreEmptyStringNullableEnumConverter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
-using System.Text.Json.Serialization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace VRCX_API.Helpers
 {

--- a/VRCX-API/Helpers/LoggerHelper.cs
+++ b/VRCX-API/Helpers/LoggerHelper.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using Serilog;
+﻿using Serilog;
 using Serilog.Events;
 
 namespace VRCX_API.Helpers

--- a/VRCX-API/Program.cs
+++ b/VRCX-API/Program.cs
@@ -34,6 +34,7 @@ namespace VRCX_API
                     options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower));
                     options.JsonSerializerOptions.Converters.Add(new IgnoreEmptyStringNullableEnumConverter());
+                    options.JsonSerializerOptions.Converters.Add(new DateTimeConverter());
                 });
 #if DEBUG
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/VRCX-API/Services/CachePeriodicService.cs
+++ b/VRCX-API/Services/CachePeriodicService.cs
@@ -2,6 +2,9 @@
 {
     public class CachePeriodicService : BackgroundService
     {
+        private const int PeriodicTimerInterval = 60;
+        private const int RefreshInterval = 120;
+
         private readonly ILogger<CachePeriodicService> _logger;
         private readonly GithubCacheService _githubCacheService;
         private readonly CloudflareService _cloudflareService;
@@ -21,12 +24,12 @@
             await _cloudflareService.PurgeCache();
             TriggerGC();
 
-            using PeriodicTimer timer = new PeriodicTimer(TimeSpan.FromSeconds(60));
+            using PeriodicTimer timer = new PeriodicTimer(TimeSpan.FromSeconds(PeriodicTimerInterval));
             while (!stoppingToken.IsCancellationRequested && await timer.WaitForNextTickAsync(stoppingToken))
             {
                 try
                 {
-                    if (DateTime.Now - _lastRefresh > TimeSpan.FromSeconds(120))
+                    if (DateTime.Now - _lastRefresh > TimeSpan.FromSeconds(RefreshInterval))
                     {
                         var hasChanged = await _githubCacheService.RefreshAsync();
                         _lastRefresh = DateTime.Now;

--- a/VRCX-API/Services/CachePeriodicService.cs
+++ b/VRCX-API/Services/CachePeriodicService.cs
@@ -31,7 +31,7 @@
                         var hasChanged = await _githubCacheService.RefreshAsync();
                         _lastRefresh = DateTime.Now;
 
-                        if(hasChanged)
+                        if (hasChanged)
                         {
                             await _cloudflareService.PurgeCache();
                         }

--- a/VRCX-API/Services/GithubCacheService.cs
+++ b/VRCX-API/Services/GithubCacheService.cs
@@ -1,8 +1,5 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
-using GitHub;
-using GitHub.Octokit.Client;
-using GitHub.Octokit.Client.Authentication;
 using VRCX_API.Configs;
 using VRCX_API.Helpers;
 
@@ -49,7 +46,6 @@ namespace VRCX_API.Services
             hasChanged |= await RefreshReleases();
             hasChanged |= await RefreshAdvisories();
 
-            // @TODO Impliment a way to see if latest releases changed.
             return hasChanged;
         }
 


### PR DESCRIPTION
Some final cleanup before the swap with v0 subdomain:
- Created `DateTimeConverter` so DateTimeOffset formatting matched GitHubs to complete parity with v0. 
- Moved Timer Intervals to constant values for easy management.
- Removed outdated TODO.
- Ran Project-wide cleanup.