### PR TITLE
Added new latest release endpoints

### DIFF
--- a/VRCX-API/Controllers/ReleasesController.cs
+++ b/VRCX-API/Controllers/ReleasesController.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
+using VRCX_API.Models;
 using VRCX_API.Services;
 
 namespace VRCX_API.Controllers
@@ -21,6 +22,8 @@ namespace VRCX_API.Controllers
         [Route("stable")]
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public IEnumerable<GitHub.Models.Release> GetStableReleases([Range(1, 101)] int page = 1, [Range(1, 101)] int pageSize = 30)
         {
             return _githubCacheService.StableReleases.Skip((page - 1) * pageSize).Take(pageSize);
@@ -29,14 +32,55 @@ namespace VRCX_API.Controllers
         [Route("stable/latest")]
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public GitHub.Models.Release? GetLastestStableRelease()
         {
             return _githubCacheService.StableReleases.FirstOrDefault();
         }
 
+        [Route("stable/latest/github")]
+        [HttpGet]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status302Found)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+        public ActionResult GetLastestStableReleaseGithub()
+        {
+            var url = _githubCacheService.StableReleases.FirstOrDefault()?.HtmlUrl;
+
+            if (url == null)
+                return NotFound();
+
+            return Redirect(url);
+        }
+
+        [Route("stable/latest/download")]
+        [HttpGet]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status302Found)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+        public ActionResult GetLastestStableReleaseDownload(DownloadType type = DownloadType.Setup)
+        {
+            var url = type switch
+            {
+                DownloadType.Checksum => _githubCacheService.StableReleases.FirstOrDefault()?.Assets?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Name) && x.Name.Equals("sha256sums.txt", StringComparison.OrdinalIgnoreCase))?.BrowserDownloadUrl,
+                DownloadType.Setup => _githubCacheService.StableReleases.FirstOrDefault()?.Assets?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Name) && x.Name.StartsWith("vrcx", StringComparison.OrdinalIgnoreCase) && x.Name.EndsWith("setup.exe", StringComparison.OrdinalIgnoreCase))?.BrowserDownloadUrl,
+                DownloadType.Zip => _githubCacheService.StableReleases.FirstOrDefault()?.Assets?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Name) && x.Name.StartsWith("vrcx", StringComparison.OrdinalIgnoreCase) && x.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))?.BrowserDownloadUrl,
+                _ => null,
+            };
+
+            if (url == null)
+                return NotFound();
+
+            return Redirect(url);
+        }
+
         [Route("nightly")]
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public IEnumerable<GitHub.Models.Release> GetNightlyReleases([Range(1, 101)] int page = 1, [Range(1, 101)] int pageSize = 30)
         {
             return _githubCacheService.NightlyReleases.Skip((page - 1) * pageSize).Take(pageSize);
@@ -45,9 +89,47 @@ namespace VRCX_API.Controllers
         [Route("nightly/latest")]
         [HttpGet]
         [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         public GitHub.Models.Release? GetLatestNightlyRelease()
         {
             return _githubCacheService.NightlyReleases.FirstOrDefault();
+        }
+
+        [Route("nightly/latest/github")]
+        [HttpGet]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status302Found)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+        public ActionResult GetLastestNightlyReleaseGithub()
+        {
+            var url = _githubCacheService.NightlyReleases.FirstOrDefault()?.HtmlUrl;
+
+            if (url == null)
+                return NotFound();
+
+            return Redirect(url);
+        }
+
+        [Route("nightly/latest/download")]
+        [HttpGet]
+        [Produces(MediaTypeNames.Application.Json)]
+        [ProducesResponseType(StatusCodes.Status302Found)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status404NotFound)]
+        public ActionResult GetLastestNightlyReleaseDownload(DownloadType type = DownloadType.Setup)
+        {
+            var url = type switch
+            {
+                DownloadType.Checksum => _githubCacheService.NightlyReleases.FirstOrDefault()?.Assets?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Name) && x.Name.Equals("sha256sums.txt", StringComparison.OrdinalIgnoreCase))?.BrowserDownloadUrl,
+                DownloadType.Setup => _githubCacheService.NightlyReleases.FirstOrDefault()?.Assets?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Name) && x.Name.StartsWith("vrcx", StringComparison.OrdinalIgnoreCase) && x.Name.EndsWith("setup.exe", StringComparison.OrdinalIgnoreCase))?.BrowserDownloadUrl,
+                DownloadType.Zip => _githubCacheService.NightlyReleases.FirstOrDefault()?.Assets?.FirstOrDefault(x => !string.IsNullOrEmpty(x.Name) && x.Name.StartsWith("vrcx", StringComparison.OrdinalIgnoreCase) && x.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))?.BrowserDownloadUrl,
+                _ => null,
+            };
+
+            if (url == null)
+                return NotFound();
+
+            return Redirect(url);
         }
     }
 }

--- a/VRCX-API/Models/DownloadType.cs
+++ b/VRCX-API/Models/DownloadType.cs
@@ -1,0 +1,9 @@
+﻿namespace VRCX_API.Models
+{
+    public enum DownloadType
+    {
+        Checksum,
+        Setup,
+        Zip
+    }
+}


### PR DESCRIPTION
- Added some more `ProducesResponseType` for swaggerdoc
- Created `/github` endpoints for the latest release
- Created `/download` endpoints for the latest release ( Closes #4 ) 